### PR TITLE
fix for empty file

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ module.exports = function(prefix, selectors) {
       var stream = fs.createReadStream(file.path);
 
       tr.pipe(concat(function concatDone(data) {
+        if (Array.isArray(data) && data.length === 0) data = null;
         file.contents = data;
         stream.close();
         cb(null, file);


### PR DESCRIPTION
```
gulp.task('prefix', function() {
    var prefixUrl = 'http://mydomain.com/asset';

    gulp.src('empty.html')
        .pipe(prefix(prefixUrl, null, true))
        .pipe(gulp.dest('build'));
});
```

```
Error: File.contents can only be a Buffer, a Stream, or null.
```

i create a empty file by `touch`, and gulp-prefix broken...
